### PR TITLE
Minimize additional features for the `zip` dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,4 @@ flate2 = "1.0.28"
 tar = "0.4.40"
 
 [target.'cfg(windows)'.build-dependencies]
-zip = "0.6.6"
+zip = { version = "0.6.6", default-features = false, features = ["deflate"] }


### PR DESCRIPTION
Zip 0.6 and later adds a lot of transitive dependencies to handle the full ZIP specification, which is rarely used in practice to be say the least. (Have you ever seen a ZIP file using Zstandard in the wild?)

This dependency is used to download `onnxruntime*.zip` in the build script, but it is small enough and the default miniz-oxide backend is not much slow enough that no other fancy feature is needed.